### PR TITLE
Add quick start guide for gg.cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ for your platform and add the binary to `PATH`.
 Once you updated the `PATH`, you can test if it worked by running `veles --help`
 in a new terminal window.
 
+### Quick start with `gg.cmd`
+
+1. Download [gg.cmd](https://github.com/eirikb/gg) from their [download link](https://github.com/eirikb/gg/releases/latest/download/gg.cmd)
+2. Linux: Run `sh -x gg.cmd gh/blazmrak/veles --help`
+3. Windows: Run `.\gg.cmd gh/blazmrak/veles --help`
+
 ### Manual
 
 Depending on how you want to run it, there are multiple options:


### PR DESCRIPTION
Sometimes, people might want to play around with a tool without installing. This community of persons might be unaware that this is very easily possible using `gg.cmd`. I would like to reach out to more persons - and thus, I propose to add `gg.cmd` here.

I'm not sure if it's really helpful fully, because `native-image` is not setup with `gg.cmd`. (I created https://github.com/eirikb/gg/discussions/220 for discussing this)